### PR TITLE
Prevent Chrome starts when running tests in Laravel Sail

### DIFF
--- a/src/Concerns/StartsChrome.php
+++ b/src/Concerns/StartsChrome.php
@@ -16,7 +16,9 @@ trait StartsChrome
      */
     public static function prepare()
     {
-        static::startChromeDriver();
+        if (! static::runningInSail()) {
+            static::startChromeDriver();
+        }
     }
 
     /**

--- a/src/Concerns/StartsChrome.php
+++ b/src/Concerns/StartsChrome.php
@@ -12,6 +12,7 @@ trait StartsChrome
      * Prepare for Dusk test execution.
      *
      * @beforeClass
+     *
      * @return void
      */
     public static function prepare()

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -24,8 +24,8 @@ abstract class TestCase extends BaseTestCase
      * Register the base URL with Dusk.
      *
      * @return void
-     * @throws \Exception
      *
+     * @throws \Exception
      * @throws \Konsulting\DuskStandalone\Exceptions\CannotCreateDirectory
      * @throws \Konsulting\DuskStandalone\Exceptions\NotADirectory
      */

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -114,4 +114,14 @@ abstract class TestCase extends BaseTestCase
     {
         throw new Exception('User resolver has not been set.');
     }
+
+    /**
+     * Determine if the tests are running within Laravel Sail.
+     *
+     * @return bool
+     */
+    protected static function runningInSail()
+    {
+        return isset($_ENV['LARAVEL_SAIL']) && $_ENV['LARAVEL_SAIL'] == '1';
+    }
 }

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -25,6 +25,7 @@ abstract class TestCase extends BaseTestCase
      *
      * @return void
      * @throws \Exception
+     *
      * @throws \Konsulting\DuskStandalone\Exceptions\CannotCreateDirectory
      * @throws \Konsulting\DuskStandalone\Exceptions\NotADirectory
      */
@@ -39,6 +40,7 @@ abstract class TestCase extends BaseTestCase
      * Setup the browser environment.
      *
      * @return void
+     *
      * @throws \Exception
      * @throws \Konsulting\DuskStandalone\Exceptions\CannotCreateDirectory
      * @throws \Konsulting\DuskStandalone\Exceptions\NotADirectory
@@ -86,6 +88,7 @@ abstract class TestCase extends BaseTestCase
      * Determine the application's base URL.
      *
      * @var string
+     *
      * @return string
      */
     protected function baseUrl()
@@ -97,6 +100,7 @@ abstract class TestCase extends BaseTestCase
      * Determine the path for Browser Tests.
      *
      * @return string
+     *
      * @throws \Exception
      */
     protected function browserTestsPath()
@@ -108,6 +112,7 @@ abstract class TestCase extends BaseTestCase
      * Get a callback that returns the default user to authenticate.
      *
      * @return void
+     *
      * @throws \Exception
      */
     protected function user()


### PR DESCRIPTION
This PR add support to Laravel Sail. When running tests in Sail, the Chrome driver is already started, thus we shouldn't start it when running tests.